### PR TITLE
feat: update meta tags and link tags based on the response from the redirect API call

### DIFF
--- a/src/dev/useInitial.ts
+++ b/src/dev/useInitial.ts
@@ -2,7 +2,7 @@ import {useState} from "react";
 import {InitialHookStatus} from "@react-buddy/ide-toolbox";
 
 export const useInitial: () => InitialHookStatus = () => {
-  const [status, setStatus] = useState<InitialHookStatus>({
+  const [status] = useState<InitialHookStatus>({
     loading: false,
     error: false,
   });


### PR DESCRIPTION
The changes in this commit update the `App` component to handle the response from the `redirect` API call. The response data includes information such as the title, description, and favicon of the redirected page. The commit adds logic to update the document title, meta tags, and link tags based on the received data. This ensures that the page displays the correct title, description, and favicon after the redirect.